### PR TITLE
Style task correction and improvement

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,14 +10,13 @@ var svgSprite = require('gulp-svg-sprite');
 
 //////////// sass Tasks //////////////
 gulp.task('style', function(){
-  gulp.src('sass/style.scss')
-      .pipe(sass())
+  gulp.src('sass/*.scss')
+      .pipe(sass().on('error', sass.logError))
       .pipe(autoprefixer(
         {
       browsers: ['last 2 versions'],
       cascade: false
     }))
-
       .pipe(gulp.dest('css/'))
       .pipe(reload({stream: true}));
 });


### PR DESCRIPTION
This small modification was made to correct a small error: the task was looking for a style.scss file, while the only .scss file in the folder was styles.scss.

With this correction, the style task will look for any .scss file directly in the sass/ folder (the content of base/ or any other subfolder won't be rendered, unless they are imported in an other .scss file at root of the sass/ folder)
I also added a method to catch errors. It will display them in the command line window.